### PR TITLE
add the token clarity contract implementing the sip-010 standard

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,21 +1,25 @@
 [project]
-name = "My-website"
-description = ""
+name = 'My-website'
+description = ''
 authors = []
 telemetry = true
-cache_dir = "./.cache"
+cache_dir = './.cache'
 
-# [contracts.counter]
-# path = "contracts/counter.clar"
-
+[[project.requirements]]
+contract_id = 'ST1NXBK3K5YYMD6FD41MVNP3JS1GABZ8TRVX023PT.sip-010-trait-ft-standard'
+[contracts.token]
+path = 'contracts/token.clar'
+clarity_version = 3
+epoch = 3.1
 [repl.analysis]
-passes = ["check_checker"]
-check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }
+passes = ['check_checker']
 
-# Check-checker settings:
-# trusted_sender: if true, inputs are trusted after tx_sender has been checked.
-# trusted_caller: if true, inputs are trusted after contract-caller has been checked.
-# callee_filter: if true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-# More informations: https://www.hiro.so/blog/new-safety-checks-in-clarinet
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false
+
+[repl.remote_data]
+enabled = false
+api_url = 'https://api.hiro.so'

--- a/contracts/token.clar
+++ b/contracts/token.clar
@@ -1,0 +1,62 @@
+
+;; title: token
+;; version:1
+;; summary:This is the fungible token for the code4stx project 
+
+
+;; traits
+(impl-trait 'ST1NXBK3K5YYMD6FD41MVNP3JS1GABZ8TRVX023PT.sip-010-trait-ft-standard.sip-010-trait);;
+
+;; token definitions
+(define-fungible-token BScoin u1000000000000)
+;;
+
+;; constants
+(define-constant err-not-token-owner (err u101))
+(define-constant err-insufficient-amount (err u102))
+(define-constant err-owner-only (err u103))
+
+;;
+
+;; data vars
+(define-data-var contract-owner principal  tx-sender)
+;;
+
+;; data maps
+;;
+
+;; public functions
+;;
+
+;; read only functions
+(define-read-only (get-name) (ok "BScoin"))
+(define-read-only (get-symbol) (ok "BSC"))
+(define-read-only (get-decimals) (ok u6))
+(define-read-only (get-balance (who principal)) (ok (ft-get-balance BScoin who)))
+(define-read-only (get-token-uri) (ok none))
+(define-read-only (get-total-supply) (ok (ft-get-supply BScoin)))
+
+;; Public function
+(define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
+    (begin
+       (asserts! (is-eq tx-sender  sender) err-not-token-owner)
+       (asserts! (> amount u0) err-insufficient-amount)
+       (try! (ft-transfer? BScoin amount sender recipient))
+       (match memo to-print (print to-print) 0x)
+       (ok true)
+    )
+)
+
+(define-public (mint (amount uint) (recipient principal))
+    (begin 
+        (asserts! (is-eq tx-sender (var-get contract-owner)) err-owner-only)
+        (ft-mint? BScoin amount recipient) 
+    )
+)
+
+(define-public (burn (amount uint) (recipient principal))
+    (begin 
+        (asserts! (is-eq tx-sender (var-get contract-owner)) err-owner-only)
+        (ft-burn? BScoin amount recipient) 
+    )
+)

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initialised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
For the code4stx journey , i have written a clarity code for the token name BScoin which has the total supply of 1000000000000. In the code, i implemented the trait ST1NXBK3K5YYMD6FD41MVNP3JS1GABZ8TRVX023PT.sip-010-trait-ft-standard and write code accordingly. 